### PR TITLE
Pin Reaktoro version to v1 until tutorials are update to v2

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
   - conda-forge
 
 dependencies:
-  - reaktoro
+  - reaktoro=1.*
   - python
   - numpy
   - jupyter


### PR DESCRIPTION
I tried to run the tutorial recently, and since v2.0.0rc* are available in conda-forge, the tutorials faced some problems. Thus, I have pinned `reaktoro=1.*` in `environment.yml` until the examples are properly updated to Reaktoro v2.0.